### PR TITLE
Update for rustdoc 1.38

### DIFF
--- a/templates/after.html
+++ b/templates/after.html
@@ -1,59 +1,40 @@
+<!--copied from otput -->
+</div>
 </section>
-<section id='search' class="content hidden"></section>
-
+<section id="search" class="content hidden"></section>
 <section class="footer"></section>
-
 <aside id="help" class="hidden">
-        <div>
-            <h1 class="hidden">Help</h1>
-
-            <div class="shortcuts">
-                <h2>Keyboard Shortcuts</h2>
-
-                <dl>
-                    <dt>?</dt>
-                    <dd>Show this help dialog</dd>
-                    <dt>S</dt>
-                    <dd>Focus the search field</dd>
-                    <dt>&larrb;</dt>
-                    <dd>Move up in search results</dd>
-                    <dt>&rarrb;</dt>
-                    <dd>Move down in search results</dd>
-                    <dt>&#9166;</dt>
-                    <dd>Go to active search result</dd>
-                    <dt>+</dt>
-                    <dd>Collapse/expand all sections</dd>
-                </dl>
-            </div>
-
-            <div class="infos">
-                <h2>Search Tricks</h2>
-
-                <p>
-                    Prefix searches with a type followed by a colon (e.g.
-                    <code>fn:</code>) to restrict the search to a given type.
-                </p>
-
-                <p>
-                    Accepted types are: <code>fn</code>, <code>mod</code>,
-                    <code>struct</code>, <code>enum</code>,
-                    <code>trait</code>, <code>type</code>, <code>macro</code>,
-                    and <code>const</code>.
-                </p>
-<p>
-                    Search functions by type signature (e.g.
-                    <code>vec -> usize</code> or <code>* -> vec</code>)
-                </p>
-            </div>
+    <div>
+        <h1 class="hidden">Help</h1>
+        <div class="shortcuts">
+            <h2>Keyboard Shortcuts</h2>
+            <dl><dt><kbd>?</kbd></dt>
+                <dd>Show this help dialog</dd><dt><kbd>S</kbd></dt>
+                <dd>Focus the search field</dd><dt><kbd>↑</kbd></dt>
+                <dd>Move up in search results</dd><dt><kbd>↓</kbd></dt>
+                <dd>Move down in search results</dd><dt><kbd>↹</kbd></dt>
+                <dd>Switch tab</dd><dt><kbd>&#9166;</kbd></dt>
+                <dd>Go to active search result</dd><dt><kbd>+</kbd></dt>
+                <dd>Expand all sections</dd><dt><kbd>-</kbd></dt>
+                <dd>Collapse all sections</dd>
+            </dl>
         </div>
-    </aside>
+        <div class="infos">
+            <h2>Search Tricks</h2>
+            <p>Prefix searches with a type followed by a colon (e.g., <code>fn:</code>) to restrict the search to a given type.</p>
+            <p>Accepted types are: <code>fn</code>, <code>mod</code>, <code>struct</code>, <code>enum</code>, <code>trait</code>, <code>type</code>, <code>macro</code>, and <code>const</code>.</p>
+            <p>Search functions by type signature (e.g., <code>vec -> usize</code> or <code>* -> vec</code>)</p>
+            <p>Search multiple things at once by splitting your query with comma (e.g., <code>str,u8</code> or <code>String,struct:Vec,test</code>)</p>
+        </div>
+    </div>
+</aside>
+<script>
+    window.rootPath = "../";
+    window.currentCrate = "{{name}}";
+</script>
+<script src="../aliases.js"></script>
+<script src="../main.js"></script>
+<script defer src="../search-index.js"></script>
+</body>
 
-
-
-    <script>
-        window.rootPath = "../../";
-        window.currentCrate = "{{name}}";
-    </script>
-    <script src="../jquery.js"></script>
-    <script src="../main.js"></script>
-    <script defer src="../search-index.js"></script>
+</html>

--- a/templates/before.html
+++ b/templates/before.html
@@ -1,30 +1,40 @@
-<style>
-.content a {
-  color: #3873AD;
-}
-.content .section-header a,
-.content .search-results a {
-  color: #000;
-}
-</style>
-
 <nav class="sidebar">
-
-  <p class='location'><a href='index.html'>{{name}}</a></p>
-    <script defer src="../sidebar-items.js"></script>
+    <div class="sidebar-menu">&#9776;</div>
+    <a href='../{{name}}/index.html'>
+        <div class='logo-container'><img src='../rust-logo.png' alt='logo'></div>
+    </a>
+    <p class='location'>Crate {{name}}</p>
+    <div class="sidebar-elems">
+        <a id='all-types' href='all.html'>
+            <p>See all {{name}}'s items</p>
+        </a>
+        <p class='location'></p>
+        <script>
+            window.sidebarCurrent = {
+                name: '{{name}}',
+                ty: 'mod',
+                relpath: '../'
+            };
+        </script>
+    </div>
 </nav>
-
+<div class="theme-picker">
+    <button id="theme-picker" aria-label="Pick another theme!"><img src="../brush.svg" width="18" alt="Pick another theme!"></button>
+    <div id="theme-choices"></div>
+</div>
+<script src="../theme.js"></script>
 <nav class="sub">
-		<form class="search-form js-only">
-				<div class="search-container">
-						<input class="search-input" name="search"
-									 autocomplete="off"
-									 placeholder="Click or press ‘S’ to search, ‘?’ for more options…"
-									 type="search">
-				</div>
-		</form>
+    <form class="search-form js-only">
+        <div class="search-container">
+            <div>
+                <select id="crate-search">
+                    <option value="All crates">All crates</option>
+                </select>
+                <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press ‘S’ to search, ‘?’ for more options…" type="search">
+            </div>
+            <a id="settings-menu" href="../settings.html"><img src="../wheel.svg" width="18" alt="Change settings"></a>
+        </div>
+    </form>
 </nav>
-
-<section id='main' class="content fn">
-
-
+<section id="main" class="content">
+    <div class='docblock'>

--- a/templates/in_header.html
+++ b/templates/in_header.html
@@ -1,0 +1,14 @@
+<link rel="stylesheet" type="text/css" href="../normalize.css">
+<link rel="stylesheet" type="text/css" href="../rustdoc.css" id="mainThemeStyle">
+<link rel="stylesheet" type="text/css" href="../dark.css">
+<link rel="stylesheet" type="text/css" href="../light.css" id="themeStyle">
+<script src="../storage.js"></script>
+<noscript>
+    <link rel="stylesheet" href="../noscript.css">
+</noscript>
+<link rel="shortcut icon" href="../favicon.ico">
+<style type="text/css">
+    #crate-search {
+        background-image: url("../down-arrow.svg");
+    }
+</style>


### PR DESCRIPTION
With rustdoc 1.38 (and probably earlier) some files that the templates depended
on don't exist anymore. This updates the templates to be compatible with the
new `css` and `js` files.